### PR TITLE
Use released binaries of graal rather than building from source

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "graal"]
-	path = graal
-	url = https://github.com/oracle/graal.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     - mercurial
 cache:
   directories:
-  - "${TRAVIS_BUILD_DIR}/../jvmci-8"
+  - "${TRAVIS_BUILD_DIR}/node_modules"
 sudo: required
 dist: trusty
 os:
@@ -18,8 +18,7 @@ os:
 - osx
 env:
   global:
-  - JVMCI_VERSION="jvmci-0.44"
-  - JDK8_UPDATE_VERSION="172"
+  - GRAAL_VERSION="1.0.0-rc5"
 before_install:
 - if [ $TRAVIS_OS_NAME = osx ]; then brew install yarn; gem update --system; fi
 install:
@@ -27,56 +26,20 @@ install:
   yarn install
   node ./download-jar.js
 - |
-  export MX_PATH=${TRAVIS_BUILD_DIR}/../mx
-  git clone https://github.com/graalvm/mx.git ${MX_PATH}
-  export PATH=${PATH}:${MX_PATH}
-- |
-  export JVMCI_JAVA=${TRAVIS_BUILD_DIR}/../jvmci-8/bin/java
-  if [ ! -f "$JVMCI_JAVA" ]; then
-    if [ $TRAVIS_OS_NAME = osx ]; then
-      brew tap caskroom/versions;
-      brew cask install java8;
-      export JAVA_HOME=/Library/Java/JavaVirtualMachines/$(ls -l1 /Library/Java/JavaVirtualMachines | tail -1)/Contents/Home;
-      git clone https://github.com/graalvm/graal-jvmci-8.git ../graal-jvmci-8;
-      cd ../graal-jvmci-8;
-      git checkout e0748378a6ee05d69da165a91690503becc8da06;
-      mx build;
-      if [ -d "${TRAVIS_BUILD_DIR}/../jvmci-8" ]; then rm -rf ${TRAVIS_BUILD_DIR}/../jvmci-8; fi
-      cp -R ${TRAVIS_BUILD_DIR}/../graal-jvmci-8/jdk1.8.0_172/darwin-amd64/product/Contents/Home ${TRAVIS_BUILD_DIR}/../jvmci-8;
-      cd ${TRAVIS_BUILD_DIR};
-    else
-      JDK_TAR=${TRAVIS_BUILD_DIR}/../jdk.tar.gz;
-      wget https://github.com/graalvm/openjdk8-jvmci-builder/releases/download/${JVMCI_VERSION}/openjdk-8u${JDK8_UPDATE_VERSION}-${JVMCI_VERSION}-linux-amd64.tar.gz -O ${JDK_TAR};
-      tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${JDK_TAR};
-      if [ -d "${TRAVIS_BUILD_DIR}/../jvmci-8" ]; then rm -rf ${TRAVIS_BUILD_DIR}/../jvmci-8; fi
-      cp -R ${TRAVIS_BUILD_DIR}/../openjdk1.8.0_${JDK8_UPDATE_VERSION}-${JVMCI_VERSION} ${TRAVIS_BUILD_DIR}/../jvmci-8;
-    fi
-  fi
-  export JAVA_HOME=${TRAVIS_BUILD_DIR}/../jvmci-8
-  export EXTRA_JAVA_HOMES=${JAVA_HOME} # JDK8 must be placed in EXTRA_JAVA_HOME
+  curl --fail -s -S -L https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-${GRAAL_VERSION}-${$TRAVIS_OS_NAME}-amd64.tar.gz | tar -x
 script:
-- echo ${JAVA_HOME}
-- echo ${EXTRA_JAVA_HOMES}
-- "${JAVA_HOME}/bin/java -version"
-- cd ${TRAVIS_BUILD_DIR}/graal && mx -v --primary-suite-path substratevm build
-- |
-  cd ${TRAVIS_BUILD_DIR}/graal/substratevm
-  mx -v native-image -H:+JNI --no-server \
+  graalvm-ce-${GRAAL_VERSION}/Contents/Home/bin/native-image -H:+JNI --no-server \
     -H:+ReportUnsupportedElementsAtRuntime \
     -H:IncludeResourceBundles=com.google.javascript.rhino.Messages \
     -H:IncludeResourceBundles=org.kohsuke.args4j.Messages \
     -H:IncludeResourceBundles=org.kohsuke.args4j.spi.Messages \
     -H:IncludeResourceBundles=com.google.javascript.jscomp.parsing.ParserConfig \
-    -H:ReflectionConfigurationFiles=${TRAVIS_BUILD_DIR}/reflection-config.json \
+    -H:ReflectionConfigurationFiles=reflection-config.json \
     -H:IncludeResources='(externs.zip)|(.*(js|txt))' \
-    -jar ${TRAVIS_BUILD_DIR}/compiler.jar
-- mv ${TRAVIS_BUILD_DIR}/graal/substratevm/compiler ${TRAVIS_BUILD_DIR}/compiler
-- cd ${TRAVIS_BUILD_DIR}
+    -jar compiler.jar
 - "./compiler --version"
 - "./compiler --help"
 - echo "console.log('hello');" | ./compiler
-after_failure:
-- cat hs_err*
 before_deploy:
 - node prepare-publish.js
 deploy:


### PR DESCRIPTION
Now that graal has new releases, use them to get the tools rather than building everything from source.